### PR TITLE
fix: implement and enforce rule severity handling

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -44,7 +44,7 @@ changelog:
 
 release:
   github:
-    owner: shanejonas
+    owner: open-rpc
     name: openrpc-linter
   draft: false
   prerelease: auto
@@ -52,10 +52,10 @@ release:
 # Homebrew tap (uncomment when you create a homebrew-tap repository)
 # brews:
 #   - name: openrpc-linter
-#     homepage: "https://github.com/shanejonas/openrpc-linter"
+#     homepage: "https://github.com/open-rpc/openrpc-linter"
 #     description: "Fast, extensible linter for OpenRPC documents"
 #     license: "MIT"
 #     repository:
-#       owner: shanejonas
+#       owner: open-rpc
 #       name: homebrew-tap
 #       branch: main 

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -36,11 +36,37 @@ archives:
         format: zip
 
 changelog:
+  use: git
   sort: asc
+  abbrev: 7
+  groups:
+    - title: "Breaking Changes"
+      regexp: '^.*?(\w+)(\([\w\s]+\))?!:.+$'
+      order: 0
+    - title: "Features"
+      regexp: '^.*?feat(\([\w\s]+\))?:.+$'
+      order: 1
+    - title: "Bug Fixes"
+      regexp: '^.*?fix(\([\w\s]+\))?:.+$'
+      order: 2
+    - title: "Performance"
+      regexp: '^.*?perf(\([\w\s]+\))?:.+$'
+      order: 3
+    - title: "Dependencies"
+      regexp: '^.*?(deps|build)(\([\w\s]+\))?:.+$'
+      order: 4
+    - title: "Other"
+      order: 999
   filters:
     exclude:
-      - "^docs:"
-      - "^test:"
+      - '^docs:'
+      - '^test:'
+      - '^chore:'
+      - '^ci:'
+      - '^style:'
+      - '^refactor:'
+      - 'Merge pull request'
+      - 'Merge branch'
 
 release:
   github:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OpenRPC Linter
 
-[![CI](https://github.com/shanejonas/openrpc-linter/workflows/CI/badge.svg)](https://github.com/shanejonas/openrpc-linter/actions)
+[![CI](https://github.com/open-rpc/openrpc-linter/workflows/CI/badge.svg)](https://github.com/open-rpc/openrpc-linter/actions)
 
 Fast, extensible linter for OpenRPC documents.
 
@@ -20,7 +20,7 @@ openrpc-linter validate openrpc.json
 ## Install
 
 ```bash
-go install github.com/shanejonas/openrpc-linter@latest
+go install github.com/open-rpc/openrpc-linter@latest
 ```
 
 ## Rules

--- a/cmd/lint.go
+++ b/cmd/lint.go
@@ -42,6 +42,23 @@ func GetReporter(format string) reporters.Reporter {
 	}
 }
 
+func normalizeSeverity(severity types.Severity) (types.Severity, error) {
+	if severity == "" {
+		return types.SeverityError, nil
+	}
+
+	switch types.Severity(strings.ToLower(string(severity))) {
+	case types.SeverityError:
+		return types.SeverityError, nil
+	case types.SeverityWarn:
+		return types.SeverityWarn, nil
+	case types.SeverityInfo:
+		return types.SeverityInfo, nil
+	default:
+		return "", fmt.Errorf("invalid severity %q; expected one of: error, warn, info", severity)
+	}
+}
+
 func RunLint(opts LintOptions) error {
 	openrpcData, err := os.ReadFile(opts.OpenRPCFile)
 	if err != nil {
@@ -80,8 +97,16 @@ func RunLint(opts LintOptions) error {
 
 	var allResults []types.RuleFunctionResult
 	totalRules := len(rulesWrapper.Rules)
+	errorCount := 0
 
 	for ruleId, rule := range rulesWrapper.Rules {
+		normalizedSeverity, err := normalizeSeverity(rule.Severity)
+		if err != nil {
+			fmt.Fprintf(opts.Output, "Error validating rules file: rule %q %v\n", ruleId, err)
+			return err
+		}
+		rule.Severity = normalizedSeverity
+
 		context := types.RuleFunctionContext{
 			Rule:             &rule,
 			RuleID:           ruleId,
@@ -92,16 +117,27 @@ func RunLint(opts LintOptions) error {
 
 		if err != nil {
 			allResults = append(allResults, types.RuleFunctionResult{
-				RuleID:  ruleId,
-				Message: err.Error(),
+				RuleID:   ruleId,
+				Message:  err.Error(),
+				Severity: types.SeverityError,
 			})
+			errorCount++
 			continue
 		}
 
+		for i := range results {
+			if results[i].RuleID == "" {
+				results[i].RuleID = ruleId
+			}
+			if results[i].Severity == "" {
+				results[i].Severity = normalizedSeverity
+			}
+			if results[i].Severity == types.SeverityError {
+				errorCount++
+			}
+		}
 		allResults = append(allResults, results...)
 	}
-
-	errorCount := len(allResults)
 
 	reporter := GetReporter(opts.Format)
 	if err := reporter.Format(allResults, totalRules, opts.Output); err != nil {

--- a/cmd/lint.go
+++ b/cmd/lint.go
@@ -7,9 +7,9 @@ import (
 	"os"
 	"strings"
 
-	"github.com/shanejonas/openrpc-linter/reporters"
-	"github.com/shanejonas/openrpc-linter/rules"
-	"github.com/shanejonas/openrpc-linter/types"
+	"github.com/open-rpc/openrpc-linter/reporters"
+	"github.com/open-rpc/openrpc-linter/rules"
+	"github.com/open-rpc/openrpc-linter/types"
 
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"

--- a/cmd/lint_test.go
+++ b/cmd/lint_test.go
@@ -86,7 +86,11 @@ rules:
 		t.Errorf("Expected 'Missing required field 'description' at $.info' in output, but got: %s", outputStr)
 	}
 
-	if !strings.Contains(outputStr, "1 error(s) found") {
+	if !strings.Contains(outputStr, "[ERROR] info-description: Missing required field 'description' at $.info") {
+		t.Errorf("Expected output to include severity and rule id, but got: %s", outputStr)
+	}
+
+	if !strings.Contains(outputStr, "Summary: 1 error(s), 0 warning(s), 0 info finding(s)") {
 		t.Errorf("Expected error summary in output, but got: %s", outputStr)
 	}
 }
@@ -161,5 +165,137 @@ rules:
 
 	if !strings.Contains(outputStr, "All 1 rules passed") {
 		t.Errorf("Expected 'All 1 rules passed' in output, but got: %s", outputStr)
+	}
+}
+
+func TestRunLintWarningSeverityDoesNotFail(t *testing.T) {
+	// Create a temporary OpenRPC file without description to trigger a truthy violation.
+	openrpcContent := map[string]interface{}{
+		"info": map[string]interface{}{
+			"title":   "Test API",
+			"version": "1.0.0",
+		},
+	}
+
+	openrpcData, err := json.Marshal(openrpcContent)
+	if err != nil {
+		t.Fatalf("Failed to create test OpenRPC content: %v", err)
+	}
+
+	tempOpenRPC, err := os.CreateTemp("", "test-openrpc-*.json")
+	if err != nil {
+		t.Fatalf("Failed to create temp OpenRPC file: %v", err)
+	}
+	defer os.Remove(tempOpenRPC.Name())
+
+	if _, err := tempOpenRPC.Write(openrpcData); err != nil {
+		t.Fatalf("Failed to write test OpenRPC file: %v", err)
+	}
+	tempOpenRPC.Close()
+
+	// severity: warn should not cause RunLint to return an error.
+	rulesContent := `description: "Test rules"
+rules:
+  info-description:
+    description: "Info must have description"
+    given: "$.info"
+    severity: "warn"
+    then:
+      field: "description"
+      function: "truthy"
+`
+
+	tempRules, err := os.CreateTemp("", "test-rules-*.yml")
+	if err != nil {
+		t.Fatalf("Failed to create temp rules file: %v", err)
+	}
+	defer os.Remove(tempRules.Name())
+
+	if _, err := tempRules.WriteString(rulesContent); err != nil {
+		t.Fatalf("Failed to write test rules file: %v", err)
+	}
+	tempRules.Close()
+
+	var output bytes.Buffer
+	opts := LintOptions{
+		OpenRPCFile: tempOpenRPC.Name(),
+		RulesFile:   tempRules.Name(),
+		Output:      &output,
+	}
+
+	err = RunLint(opts)
+	if err != nil {
+		t.Fatalf("RunLint should not fail for warn severity violations, but got: %v\nOutput:\n%s", err, output.String())
+	}
+
+	outputStr := output.String()
+	if !strings.Contains(outputStr, "[WARN] info-description: Missing required field 'description' at $.info") {
+		t.Fatalf("Expected warn severity finding in output, got:\n%s", outputStr)
+	}
+	if !strings.Contains(outputStr, "Summary: 0 error(s), 1 warning(s), 0 info finding(s)") {
+		t.Fatalf("Expected warning summary in output, got:\n%s", outputStr)
+	}
+}
+
+func TestRunLintInvalidSeverityFailsFast(t *testing.T) {
+	openrpcContent := map[string]interface{}{
+		"info": map[string]interface{}{
+			"title":   "Test API",
+			"version": "1.0.0",
+		},
+	}
+
+	openrpcData, err := json.Marshal(openrpcContent)
+	if err != nil {
+		t.Fatalf("Failed to create test OpenRPC content: %v", err)
+	}
+
+	tempOpenRPC, err := os.CreateTemp("", "test-openrpc-*.json")
+	if err != nil {
+		t.Fatalf("Failed to create temp OpenRPC file: %v", err)
+	}
+	defer os.Remove(tempOpenRPC.Name())
+
+	if _, err := tempOpenRPC.Write(openrpcData); err != nil {
+		t.Fatalf("Failed to write test OpenRPC file: %v", err)
+	}
+	tempOpenRPC.Close()
+
+	rulesContent := `description: "Test rules"
+rules:
+  info-description:
+    description: "Info must have description"
+    given: "$.info"
+    severity: "critical"
+    then:
+      field: "description"
+      function: "truthy"
+`
+
+	tempRules, err := os.CreateTemp("", "test-rules-*.yml")
+	if err != nil {
+		t.Fatalf("Failed to create temp rules file: %v", err)
+	}
+	defer os.Remove(tempRules.Name())
+
+	if _, err := tempRules.WriteString(rulesContent); err != nil {
+		t.Fatalf("Failed to write test rules file: %v", err)
+	}
+	tempRules.Close()
+
+	var output bytes.Buffer
+	opts := LintOptions{
+		OpenRPCFile: tempOpenRPC.Name(),
+		RulesFile:   tempRules.Name(),
+		Output:      &output,
+	}
+
+	err = RunLint(opts)
+	if err == nil {
+		t.Fatalf("Expected RunLint to fail for invalid severity")
+	}
+
+	if !strings.Contains(err.Error(), "invalid severity") {
+		t.Fatalf("Expected invalid severity error, got: %v", err)
 	}
 }

--- a/functions/registry.go
+++ b/functions/registry.go
@@ -1,6 +1,6 @@
 package functions
 
-import "github.com/shanejonas/openrpc-linter/types"
+import "github.com/open-rpc/openrpc-linter/types"
 
 var FunctionRegistry = make(map[string]types.RuleFunction)
 

--- a/functions/truthy.go
+++ b/functions/truthy.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/shanejonas/openrpc-linter/types"
+	"github.com/open-rpc/openrpc-linter/types"
 
 	"github.com/santhosh-tekuri/jsonschema/v6"
 )

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/shanejonas/openrpc-linter
+module github.com/open-rpc/openrpc-linter
 
 go 1.24.4
 

--- a/main.go
+++ b/main.go
@@ -1,6 +1,6 @@
 package main
 
-import "github.com/shanejonas/openrpc-linter/cmd"
+import "github.com/open-rpc/openrpc-linter/cmd"
 
 func main() {
 	cmd.Execute()

--- a/reporters/json_reporter.go
+++ b/reporters/json_reporter.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"io"
 
-	"github.com/shanejonas/openrpc-linter/types"
+	"github.com/open-rpc/openrpc-linter/types"
 )
 
 type JSONReporter struct{}

--- a/reporters/reporter.go
+++ b/reporters/reporter.go
@@ -3,7 +3,7 @@ package reporters
 import (
 	"io"
 
-	"github.com/shanejonas/openrpc-linter/types"
+	"github.com/open-rpc/openrpc-linter/types"
 )
 
 type Reporter interface {

--- a/reporters/text_reporter.go
+++ b/reporters/text_reporter.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/shanejonas/openrpc-linter/types"
+	"github.com/open-rpc/openrpc-linter/types"
 )
 
 type TextReporter struct{}

--- a/reporters/text_reporter.go
+++ b/reporters/text_reporter.go
@@ -3,6 +3,7 @@ package reporters
 import (
 	"fmt"
 	"io"
+	"strings"
 
 	"github.com/open-rpc/openrpc-linter/types"
 )
@@ -11,30 +12,64 @@ type TextReporter struct{}
 
 func (r *TextReporter) Format(results []types.RuleFunctionResult, totalRules int, output io.Writer) error {
 	errorCount := 0
-	ruleErrors := make(map[string][]string)
+	warnCount := 0
+	infoCount := 0
 
 	for _, result := range results {
 		if result.Message != "" {
-			ruleErrors[result.RuleID] = append(ruleErrors[result.RuleID], result.Message)
-			errorCount++
-		}
-	}
+			switch result.Severity {
+			case types.SeverityWarn:
+				warnCount++
+			case types.SeverityInfo:
+				infoCount++
+			default:
+				errorCount++
+			}
 
-	for ruleId, messages := range ruleErrors {
-		for _, message := range messages {
-			if _, err := fmt.Fprintf(output, "❌ %s: %s\n", ruleId, message); err != nil {
+			ruleID := result.RuleID
+			if ruleID == "" {
+				ruleID = "-"
+			}
+
+			severity := result.Severity
+			if severity == "" {
+				severity = types.SeverityError
+			}
+
+			icon := "❌"
+			switch severity {
+			case types.SeverityWarn:
+				icon = "⚠️"
+			case types.SeverityInfo:
+				icon = "ℹ️"
+			}
+
+			if _, err := fmt.Fprintf(
+				output,
+				"%s [%s] %s: %s\n",
+				icon,
+				strings.ToUpper(string(severity)),
+				ruleID,
+				result.Message,
+			); err != nil {
 				return err
 			}
 		}
 	}
 
-	if errorCount == 0 {
+	totalFindings := errorCount + warnCount + infoCount
+	if totalFindings == 0 {
 		if _, err := fmt.Fprintf(output, "\n✅ All %d rules passed!\n", totalRules); err != nil {
 			return err
 		}
 	} else {
-		rulesWithErrors := len(ruleErrors)
-		if _, err := fmt.Fprintf(output, "\n❌ %d error(s) found in %d rules\n", errorCount, rulesWithErrors); err != nil {
+		if _, err := fmt.Fprintf(
+			output,
+			"\nSummary: %d error(s), %d warning(s), %d info finding(s)\n",
+			errorCount,
+			warnCount,
+			infoCount,
+		); err != nil {
 			return err
 		}
 	}

--- a/rules/rules.go
+++ b/rules/rules.go
@@ -3,8 +3,8 @@ package rules
 import (
 	"fmt"
 
-	"github.com/shanejonas/openrpc-linter/functions"
-	"github.com/shanejonas/openrpc-linter/types"
+	"github.com/open-rpc/openrpc-linter/functions"
+	"github.com/open-rpc/openrpc-linter/types"
 
 	"github.com/PaesslerAG/jsonpath"
 	"gopkg.in/yaml.v3"

--- a/rules/rules_test.go
+++ b/rules/rules_test.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/shanejonas/openrpc-linter/types"
+	"github.com/open-rpc/openrpc-linter/types"
 
 	"gopkg.in/yaml.v3"
 )

--- a/types/types.go
+++ b/types/types.go
@@ -4,11 +4,20 @@ import (
 	"github.com/santhosh-tekuri/jsonschema/v6"
 )
 
+type Severity string
+
+const (
+	SeverityError Severity = "error"
+	SeverityWarn  Severity = "warn"
+	SeverityInfo  Severity = "info"
+)
+
 type Rule struct {
-	Description string      `json:"description"`
-	Given       string      `json:"given,omitempty"`
-	Then        *RuleAction `json:"then,omitempty"`
-	Extends     interface{} `json:"extends,omitempty"`
+	Description string      `json:"description" yaml:"description"`
+	Given       string      `json:"given,omitempty" yaml:"given,omitempty"`
+	Then        *RuleAction `json:"then,omitempty" yaml:"then,omitempty"`
+	Extends     interface{} `json:"extends,omitempty" yaml:"extends,omitempty"`
+	Severity    Severity    `json:"severity,omitempty" yaml:"severity,omitempty"`
 }
 
 type RuleAction struct {
@@ -18,9 +27,10 @@ type RuleAction struct {
 }
 
 type RuleFunctionResult struct {
-	Message string   `json:"message,omitempty"`
-	Path    []string `json:"path,omitempty"`
-	RuleID  string   `json:"ruleId,omitempty"`
+	Message  string   `json:"message,omitempty"`
+	Path     []string `json:"path,omitempty"`
+	RuleID   string   `json:"ruleId,omitempty"`
+	Severity Severity `json:"severity,omitempty"`
 }
 
 type RuleFunctionSchema struct {


### PR DESCRIPTION
## Summary
- add first-class severity support (`error`, `warn`, `info`) to rule and result types
- validate and normalize rule severity during lint execution
- propagate rule id + severity onto every finding and only fail lint on `error` findings
- improve text output to include severity labels and a severity-based summary
- add tests for warning behavior and invalid severity rejection

## Verification
- go test ./...
